### PR TITLE
Use PyPA action for PyPI Publish

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -162,7 +162,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish to PyPI
-        env:
-          TWINE_USERNAME: __token__
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-        run: pipx run twine upload dist/*.whl dist/*.tar.gz

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -164,4 +164,4 @@ jobs:
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+          password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
Use the official Python Packaging Authority (PyPA) Action to publish to PyPI