### PR TITLE
move requirements assets to lockfiles zip

### DIFF
--- a/.containerignore
+++ b/.containerignore
@@ -1,7 +1,0 @@
-Dockerfile
-build/
-dist/
-.mypy_cache
-.tox
-.venv*
-venv*

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+build/
+dist/
+.mypy_cache
+.tox
+.venv*
+venv*
+.devcontainer.json
+.pre-commit-config.yaml
+.vscode
+README.rst

--- a/.dockerignore
+++ b/.dockerignore
@@ -4,5 +4,3 @@ dist/
 .tox
 .venv*
 venv*
-.pre-commit-config.yaml
-.vscode

--- a/.dockerignore
+++ b/.dockerignore
@@ -4,7 +4,5 @@ dist/
 .tox
 .venv*
 venv*
-.devcontainer.json
 .pre-commit-config.yaml
 .vscode
-README.rst

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -110,6 +110,7 @@ jobs:
         run: |
           docker run --name test build bash /project/.github/workflows/container_tests.sh
           docker cp test:/project/dist .
+          docker cp test:/project/lockfiles .
           docker cp test:/project/cov.xml .
 
       - name: Upload coverage to Codecov
@@ -141,6 +142,12 @@ jobs:
           name: dist
           path: dist
 
+      - name: Upload lock files
+        uses: actions/upload-artifact@v3
+        with:
+          name: lockfiles
+          path: lockfiles
+
   release:
     # upload to PyPI and make a release on every tag
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
@@ -156,7 +163,9 @@ jobs:
         uses: softprops/action-gh-release@1e07f4398721186383de40550babbdf2b84acfc5 # v0.1.14
         with:
           prerelease: ${{ contains(github.ref_name, 'a') || contains(github.ref_name, 'b') || contains(github.ref_name, 'rc') }}
-          files: dist/*
+          files: |
+            dist/
+            lockfiles/
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/container_tests.sh
+++ b/.github/workflows/container_tests.sh
@@ -6,7 +6,8 @@ source /venv/bin/activate
 
 touch requirements_dev.txt
 pip install -r requirements_dev.txt -e .[dev]
-pip freeze --exclude-editable > dist/requirements_dev.txt
+mkdir -p lockfiles
+pip freeze --exclude-editable > lockfiles/requirements_dev.txt
 
 pipdeptree
 

--- a/.gitignore
+++ b/.gitignore
@@ -64,4 +64,6 @@ target/
 .venv*
 venv*
 
+# further build artifacts
+lockfiles/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ WORKDIR /project
 # make the wheel outside of the venv so 'build' does not dirty requirements.txt
 RUN pip install --upgrade pip build && \
     export SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct) && \
-    python -m build --sdist --wheel && \
+    python -m build && \
     touch requirements.txt
 
 # set up a virtual environment and put it in PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ WORKDIR /project
 # make the wheel outside of the venv so 'build' does not dirty requirements.txt
 RUN pip install --upgrade pip build && \
     export SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct) && \
+    git diff && \
     python -m build && \
     touch requirements.txt
 


### PR DESCRIPTION
This is my attempt to make Garry's addition of pypa/gh-action-pypi-publish@release/v1 work by moving the requires*.txt files from dist/ to lockfiles/.

It also includes a little tidying of the Dockerfile.

HOWEVER: it does not work when I test merge into skeleton-cli. For some reason PyPi does not like the README.rst. I can't tell if we have made a breaking change to README.rst or if it is a nuance of the Pypi GHA itself.

https://github.com/DiamondLightSource/python3-pip-skeleton-cli/actions/runs/3271895142/jobs/5382285315