### PR TITLE
Use importlib.metadata to get package version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ dev = [
     "pre-commit",
     "pydata-sphinx-theme",
     "pytest-cov",
-    "setuptools_scm[toml]>=6.2",
     "sphinx-autobuild",
     "sphinx-copybutton",
     "sphinx-design",

--- a/src/python3_pip_skeleton/__init__.py
+++ b/src/python3_pip_skeleton/__init__.py
@@ -1,12 +1,6 @@
-try:
-    # Use live version from git
-    from setuptools_scm import get_version
+from importlib.metadata import version
 
-    # Warning: If the install is nested to the same depth, this will always succeed
-    __version__ = get_version(root="../../", relative_to=__file__)
-    del get_version
-except (ImportError, LookupError):
-    # Use installed version
-    from ._version import __version__
+__version__ = version("python3-pip-skeleton")
+del version
 
 __all__ = ["__version__"]


### PR DESCRIPTION
Simplify getting version data with use of `importlib.metadata`, removes the dev requirement of `setuptools_scm`