### PR TITLE
add version label to container registry push

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -160,6 +160,7 @@ jobs:
           push: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags') }}
           load: ${{ ! (github.event_name == 'push' && startsWith(github.ref, 'refs/tags')) }}
           tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           context: .devcontainer
           # If you have a long docker build, uncomment the following to turn on caching
           # For short build times this makes it a little slower


### PR DESCRIPTION
This makes it possible to verify the version label of a container pulled using 'latest' tag.