### PR TITLE
Don't check switcher if not published

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,8 +4,11 @@
 # list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
+import sys
 from pathlib import Path
 from subprocess import check_output
+
+import requests
 
 import python3_pip_skeleton
 
@@ -126,6 +129,17 @@ copybutton_prompt_is_regexp = True
 html_theme = "pydata_sphinx_theme"
 github_repo = project
 github_user = "DiamondLightSource"
+switcher_json = f"https://{github_user}.github.io/{github_repo}/switcher.json"
+# Don't check switcher if it doesn't exist, but warn in a non-failing way
+check_switcher = requests.get(switcher_json).ok
+if not check_switcher:
+    print(
+        "*** Can't read version switcher, is GitHub pages enabled? \n"
+        "    Once Docs CI job has successfully run once, set the "
+        "Github pages source branch to be 'gh-pages' at:\n"
+        f"    https://github.com/{github_user}/{github_repo}/settings/pages",
+        file=sys.stderr,
+    )
 
 # Theme options for pydata_sphinx_theme
 html_theme_options = dict(
@@ -142,9 +156,10 @@ html_theme_options = dict(
         )
     ],
     switcher=dict(
-        json_url=f"https://{github_user}.github.io/{github_repo}/switcher.json",
+        json_url=switcher_json,
         version_match=version,
     ),
+    check_switcher=check_switcher,
     navbar_end=["theme-switcher", "icon-links", "version-switcher"],
     external_links=[
         dict(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dev = [
     "Flake8-pyproject",
     "pipdeptree",
     "pre-commit",
-    "pydata-sphinx-theme",
+    "pydata-sphinx-theme>=0.12",
     "pytest-cov",
     "sphinx-autobuild",
     "sphinx-copybutton",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,8 @@ dev = [
     "black",
     "isort",
     "mypy",
-    "flake8",
+    # https://github.com/john-hen/Flake8-pyproject/issues/12
+    "flake8<6",
     "flake8-isort",
     "Flake8-pyproject",
     "pipdeptree",


### PR DESCRIPTION
- pydata-sphinx-theme 0.11 started checking switcher
- this meant you couldn't bootstrap a gh-pages build
- pydata-sphinx-theme 0.12 put in an option not to check
- but we want checking if the file exists
- so only check if we can get the json file
- and suggest user turns pages on if we can't