### PR TITLE
Remove unused matrix from linkcheck CI

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -8,11 +8,6 @@ on:
 
 jobs:
   docs:
-    strategy:
-      fail-fast: false
-      matrix:
-        python: ["3.10"]
-
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
The matrix in `linkcheck` was not being used, thus I have removed it. Should we pin the python version?