### PR TITLE
Re-add conda build & publish from CI

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -170,13 +170,42 @@ jobs:
       - name: Test cli works in runtime image
         run: docker run ${{ env.IMAGE_REPOSITORY }} --version
 
+  conda:
+    needs: [dist]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/download-artifact@v3
+
+      - name: Create Conda recipe
+        run: |
+          mkdir -p conda/recipe
+          pipx run grayskull pypi -o conda/recipe dist/*.tar.gz
+
+      - name: Install conda-build
+        run: conda install -y conda-build
+
+      - name: Build Conda distribution
+        run: |
+          mkdir -p conda/build
+          conda build --output-folder conda/build conda/recipe/*/meta.yaml
+
+      - name: Upload conda build
+        uses: actions/upload-artifact@v3
+        with:
+          name: conda_build
+          path: |
+            conda/build/
+            !conda/build/*/.cache
+
   release:
     # upload to PyPI and make a release on every tag
-    needs: [lint, dist, test]
+    needs: [lint, dist, test, conda]
     if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags') }}
     runs-on: ubuntu-latest
     env:
       HAS_PYPI_TOKEN: ${{ secrets.PYPI_TOKEN != '' }}
+      HAS_ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN != '' }}
 
     steps:
       - uses: actions/download-artifact@v3
@@ -203,3 +232,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_TOKEN }}
+
+      - name: Publish to Anaconda
+        if: ${{ env.HAS_ANACONDA_TOKEN }}
+        run: pipx run --spec anaconda-client anaconda --token ${{ secrets.ANACONDA_TOKEN }} upload conda_build/noarch/*.tar.bz2

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 python3-pip-skeleton
 ===========================
 
-|code_ci| |docs_ci| |coverage| |pypi_version| |license|
+|code_ci| |docs_ci| |coverage| |pypi_version| |anaconda_version| |license|
 
 .. note::
 
@@ -14,6 +14,7 @@ how it does it, and why people should use it.
 
 ============== ==============================================================
 PyPI           ``pip install python3-pip-skeleton``
+Conda          ``conda install -c DiamondLightSource python3-pip-skeleton``
 Source code    https://github.com/DiamondLightSource/python3-pip-skeleton
 Documentation  https://DiamondLightSource.github.io/python3-pip-skeleton
 Releases       https://github.com/DiamondLightSource/python3-pip-skeleton/releases
@@ -48,6 +49,10 @@ Or if it is a commandline tool then you might put some example commands here::
 .. |pypi_version| image:: https://img.shields.io/pypi/v/python3-pip-skeleton.svg
     :target: https://pypi.org/project/python3-pip-skeleton
     :alt: Latest PyPI version
+
+.. |anaconda_version| image:: https://anaconda.org/DiamondLightSource/python3-pip-skeleton/badges/version.svg
+    :target: https://anaconda.org/DiamondLightSource/python3-pip-skeleton
+    :alt: Latest Anaconda version
 
 .. |license| image:: https://img.shields.io/badge/License-Apache%202.0-blue.svg
     :target: https://opensource.org/licenses/Apache-2.0


### PR DESCRIPTION
Re-add conda build to CI. Pending `pyproject.toml` compatibility from grayskull (see: https://github.com/conda-incubator/grayskull/pull/394)