### PR TITLE
Stop checking switcher in docs build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -130,9 +130,8 @@ html_theme = "pydata_sphinx_theme"
 github_repo = project
 github_user = "DiamondLightSource"
 switcher_json = f"https://{github_user}.github.io/{github_repo}/switcher.json"
-# Don't check switcher if it doesn't exist, but warn in a non-failing way
-check_switcher = requests.get(switcher_json).ok
-if not check_switcher:
+switcher_exists = requests.get(switcher_json).ok
+if not switcher_exists:
     print(
         "*** Can't read version switcher, is GitHub pages enabled? \n"
         "    Once Docs CI job has successfully run once, set the "
@@ -142,6 +141,14 @@ if not check_switcher:
     )
 
 # Theme options for pydata_sphinx_theme
+# We don't check switcher because there are 3 possible states for a repo:
+# 1. New project, docs are not published so there is no switcher
+# 2. Existing project with latest skeleton, switcher exists and works
+# 3. Existing project with old skeleton that makes broken switcher,
+#    switcher exists but is broken
+# Point 3 makes checking switcher difficult, because the updated skeleton
+# will fix the switcher at the end of the docs workflow, but never gets a chance
+# to complete as the docs build warns and fails.
 html_theme_options = dict(
     logo=dict(
         text=project,
@@ -159,7 +166,7 @@ html_theme_options = dict(
         json_url=switcher_json,
         version_match=version,
     ),
-    check_switcher=check_switcher,
+    check_switcher=False,
     navbar_end=["theme-switcher", "icon-links", "version-switcher"],
     external_links=[
         dict(


### PR DESCRIPTION
We don't want to check switcher because there are 3 possible states for a repo:

1. New project, docs are not published so there is no switcher
2. Existing project with latest skeleton, switcher should be there
3. Existing project with skeleton being either adopted or updated, switcher may or mar not be there and its state is unknown.

Point 3 makes checking switcher difficult, because if it is not as the theme expects, it needs to be manually fixed on every branch.
This PR sets `check_switcher` to `False` and adds a comment explaining why.