### PR TITLE
104 remove scheduled job in code yaml

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -3,9 +3,7 @@ name: Code CI
 on:
   push:
   pull_request:
-  schedule:
-    # Run weekly to check latest versions of dependencies
-    - cron: "0 8 * * WED"
+
 env:
   # The target python version, which must match the Dockerfile version
   CONTAINER_PYTHON: "3.11"

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -22,3 +22,6 @@ jobs:
 
       - name: Check links
         run: tox -e docs build -- -b linkcheck
+      
+      - name: Keepalive Workflow
+        uses: gautamkrishnar/keepalive-workflow@v1

--- a/docs/developer/explanations/decisions/0002-switched-to-pip-skeleton.rst
+++ b/docs/developer/explanations/decisions/0002-switched-to-pip-skeleton.rst
@@ -1,0 +1,34 @@
+2. Adopt python3-pip-skeleton for project structure
+===================================================
+
+Date: 2022-02-18
+
+Status
+------
+
+Accepted
+
+Context
+-------
+
+We should use the diamond light source `python3-pip-skeleton <https://github.com/DiamondLightSource/python3-pip-skeleton>`_.
+The skeleton is used across Diamond to ensure consistency in developer
+environments and package management.
+
+Decision
+--------
+
+We have switched to using the skeleton.
+
+Consequences
+------------
+
+This module will use a fixed set of tools as developed in python3-pip-skeleton
+and can pull from this skeleton to update the packaging to the latest techniques.
+
+As such, the developer environment may have changed, the following could be
+different:
+* linting
+* formatting
+* pip venv setup
+* CI/CD

--- a/docs/developer/explanations/decisions/0002-switched-to-pip-skeleton.rst
+++ b/docs/developer/explanations/decisions/0002-switched-to-pip-skeleton.rst
@@ -11,8 +11,8 @@ Accepted
 Context
 -------
 
-We should use the diamond light source `python3-pip-skeleton <https://github.com/DiamondLightSource/python3-pip-skeleton>`_.
-The skeleton is used across Diamond to ensure consistency in developer
+We should use the following `pip-skeleton <https://github.com/DiamondLightSource/python3-pip-skeleton>`_.
+The skeleton will ensure consistency in developer
 environments and package management.
 
 Decision
@@ -28,7 +28,8 @@ and can pull from this skeleton to update the packaging to the latest techniques
 
 As such, the developer environment may have changed, the following could be
 different:
-* linting
-* formatting
-* pip venv setup
-* CI/CD
+
+- linting
+- formatting
+- pip venv setup
+- CI/CD

--- a/tests/test_boilerplate_removed.py
+++ b/tests/test_boilerplate_removed.py
@@ -21,7 +21,7 @@ def assert_not_contains_text(path: str, text: str, explanation: str):
     full_path = ROOT / path
     if full_path.exists():
         contents = full_path.read_text().replace("\n", " ")
-        skeleton_check(text in contents, f"Please change ./ {path} {explanation}")
+        skeleton_check(text in contents, f"Please change ./{path} {explanation}")
 
 
 # pyproject.toml

--- a/tests/test_boilerplate_removed.py
+++ b/tests/test_boilerplate_removed.py
@@ -21,7 +21,7 @@ def assert_not_contains_text(path: str, text: str, explanation: str):
     full_path = ROOT / path
     if full_path.exists():
         contents = full_path.read_text().replace("\n", " ")
-        skeleton_check(text in contents, f"Please change ./{path} {explanation}")
+        skeleton_check(text in contents, f"Please change ./ {path} {explanation}")
 
 
 # pyproject.toml


### PR DESCRIPTION
Closes #104 

Removes the scheduled job in `code.yaml` and adds [keepalive-workflow](https://github.com/gautamkrishnar/keepalive-workflow) to prevent inactivity after 60 days.


We established there would be inactivity after 60 days in #104.:

              Looks like this is still a problem:
![image](https://user-images.githubusercontent.com/101418278/214086670-2c3e1ec3-6961-46f9-8f3d-d1624eec277c.png)
I think we should go ahead and remove the schedule from code.yaml, and add the [keepalive-workflow](https://github.com/marketplace/actions/keepalive-workflow) as the last step of linkcheck

_Originally posted by @coretl in https://github.com/DiamondLightSource/python3-pip-skeleton/issues/104#issuecomment-1400588421_