### PR TITLE
removed scheduled job in code.yaml and added keepalive-workflow

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -3,9 +3,6 @@ name: Code CI
 on:
   push:
   pull_request:
-  schedule:
-    # Run weekly to check latest versions of dependencies
-    - cron: "0 8 * * WED"
 env:
   # The target python version, which must match the Dockerfile version
   CONTAINER_PYTHON: "3.11"

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -22,3 +22,6 @@ jobs:
 
       - name: Check links
         run: tox -e docs build -- -b linkcheck
+
+      - name: Keepalive Workflow
+        uses: gautamkrishnar/keepalive-workflow@v1


### PR DESCRIPTION
Closes #104 

Removes the scheduled job in `code.yaml` and adds [keepalive-workflow](https://github.com/gautamkrishnar/keepalive-workflow) to prevent inactivity after 60 days.


We established there would be inactivity after 60 days in #104.:

              Looks like this is still a problem:
![image](https://user-images.githubusercontent.com/101418278/214086670-2c3e1ec3-6961-46f9-8f3d-d1624eec277c.png)
I think we should go ahead and remove the schedule from code.yaml, and add the [keepalive-workflow](https://github.com/marketplace/actions/keepalive-workflow) as the last step of linkcheck

_Originally posted by @coretl in https://github.com/DiamondLightSource/python3-pip-skeleton/issues/104#issuecomment-1400588421_