### PR TITLE
#118 changed to use '[dev]' instead of [dev] in the docs

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -50,5 +50,5 @@
     "workspaceMount": "source=${localWorkspaceFolder},target=${localWorkspaceFolder},type=bind",
     "workspaceFolder": "${localWorkspaceFolder}",
     // After the container is created, install the python project in editable form
-    "postCreateCommand": "pip install -e .[dev]"
+    "postCreateCommand": "pip install -e '.[dev]'"
 }

--- a/docs/developer/tutorials/dev-install.rst
+++ b/docs/developer/tutorials/dev-install.rst
@@ -28,7 +28,7 @@ requires python 3.8 or later) or to run in a container under `VSCode
             $ cd python3-pip-skeleton
             $ python3 -m venv venv
             $ source venv/bin/activate
-            $ pip install -e .[dev]
+            $ pip install -e '.[dev]'
 
     .. tab-item:: VSCode devcontainer
 


### PR DESCRIPTION
Closes #118 

A minor change to the docs so we can pull python-pip-skeleton to python3-pip-skeleton-cli to close [this pr](https://github.com/DiamondLightSource/python3-pip-skeleton-cli/pull/65).