### PR TITLE
Add explicit dependency on pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dev = [
     "pipdeptree",
     "pre-commit",
     "pydata-sphinx-theme>=0.12",
+    "pytest",
     "pytest-cov",
     "sphinx-autobuild",
     "sphinx-copybutton",


### PR DESCRIPTION
The `pyproject.toml` file has specific configuration for `pytest`, but did not include it as a dependency - it was only installed as a dependency of `pytest-cov`. This led to the scenario where, if for any reason you didn't want the coverage plugin and so uninstalled it, you would also lose the ability to run tests.

I did debate whether `flake8` should also be listed - it does also have direct configuration but not directly depended on - but I think the wrapper project (`flake8-isort`) is a fair replacement as I'd expect that removing it that `flake8` and `isort` would stop working properly. 

All other modules references in the `pyproject.toml` file are already explicitly depended on.