### PR TITLE
Use `actions/github-pages` to publish docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Write switcher.json
         run: python .github/pages/make_switcher.py --add $DOCS_VERSION ${{ github.repository }} .github/pages/switcher.json
 
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v1.0.8
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,7 +8,12 @@ jobs:
   docs:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
-
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Avoid git conflicts when tag and branch pushed at same time
         if: startsWith(github.ref, 'refs/tags')
@@ -42,12 +47,12 @@ jobs:
       - name: Write switcher.json
         run: python .github/pages/make_switcher.py --add $DOCS_VERSION ${{ github.repository }} .github/pages/switcher.json
 
-      - name: Publish Docs to gh-pages
-        if: github.event_name == 'push' && github.actor != 'dependabot[bot]'
-        # We pin to the SHA, not the tag, for security reasons.
-        # https://docs.github.com/en/actions/learn-github-actions/security-hardening-for-github-actions#using-third-party-actions
-        uses: peaceiris/actions-gh-pages@64b46b4226a4a12da2239ba3ea5aa73e3163c75b # v3.9.1
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v1.0.8
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: .github/pages
-          keep_files: true
+          path: .github/pages
+
+      - name: Publish docs to GitHub Pages
+        if: github.event_name == 'push' && github.actor != 'dependabot[bot]'
+        id: deployment
+        uses: actions/github-pages@v2.0.1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -58,4 +58,4 @@ jobs:
       - name: Publish docs to GitHub Pages
         if: github.event_name == 'push' && github.actor != 'dependabot[bot]'
         id: deployment
-        uses: actions/github-pages@v2.0.1
+        uses: actions/deploy-pages@v2.0.1


### PR DESCRIPTION
Uses the official `actions/github-pages` action to publish docs to GitHub Pages. This should remove the need for `gh-pages` branch