### PR TITLE
Slight changes to the sed command, and ensuring output is utf-8 on windows

### DIFF
--- a/.github/actions/install_requirements/action.yml
+++ b/.github/actions/install_requirements/action.yml
@@ -32,7 +32,7 @@ runs:
         mkdir -p lockfiles
         pip freeze --exclude-editable > lockfiles/${{ inputs.requirements_file }}
         # delete the self referencing line and make sure it isn't blank
-        sed -i '/file:/d' lockfiles/${{ inputs.requirements_file }}
+        sed -i'' -e '/file:/d' lockfiles/${{ inputs.requirements_file }}
       shell: bash
 
     - name: Upload lockfiles

--- a/.github/pages/make_switcher.py
+++ b/.github/pages/make_switcher.py
@@ -64,7 +64,7 @@ def write_json(path: Path, repository: str, versions: str):
     ]
     text = json.dumps(struct, indent=2)
     print(f"JSON switcher:\n{text}")
-    path.write_text(text)
+    path.write_text(text, encoding="utf-8")
 
 
 def main(args=None):


### PR DESCRIPTION
Changing `.github` stuff here so the skeleton works with windows/mac. Other changes are to the cli, detailed here https://github.com/DiamondLightSource/python3-pip-skeleton-cli/pull/88