### PR TITLE
Use ruff as a linter as a replacement for flake8/isort

### DIFF
--- a/.github/pages/make_switcher.py
+++ b/.github/pages/make_switcher.py
@@ -59,7 +59,7 @@ def get_versions(ref: str, add: Optional[str], remove: Optional[str]) -> List[st
 def write_json(path: Path, repository: str, versions: str):
     org, repo_name = repository.split("/")
     struct = [
-        dict(version=version, url=f"https://{org}.github.io/{repo_name}/{version}/")
+        {"version": version, "url": f"https://{org}.github.io/{repo_name}/{version}/"}
         for version in versions
     ]
     text = json.dumps(struct, indent=2)

--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ venv*
 
 # further build artifacts
 lockfiles/
+
+# ruff cache
+.ruff_cache/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,9 +15,9 @@ repos:
         entry: black --check --diff
         types: [python]
 
-      - id: flake8
-        name: Run flake8
+      - id: ruff
+        name: Run ruff
         stages: [commit]
         language: system
-        entry: flake8
+        entry: ruff
         types: [python]

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,6 +4,7 @@
         "ms-python.python",
         "tamasfe.even-better-toml",
         "redhat.vscode-yaml",
-        "ryanluker.vscode-coverage-gutters"
+        "ryanluker.vscode-coverage-gutters",
+        "charliermarsh.Ruff"
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,15 +1,22 @@
 {
     "python.linting.pylintEnabled": false,
-    "python.linting.flake8Enabled": true,
+    "python.linting.flake8Enabled": false,
     "python.linting.mypyEnabled": true,
     "python.linting.enabled": true,
-    "python.testing.pytestArgs": ["--cov=python3_pip_skeleton", "--cov-report", "xml:cov.xml"],
+    "python.testing.pytestArgs": [
+        "--cov=python3_pip_skeleton",
+        "--cov-report",
+        "xml:cov.xml"
+    ],
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true,
     "python.formatting.provider": "black",
     "python.languageServer": "Pylance",
     "editor.formatOnSave": true,
-    "editor.codeActionsOnSave": {
-        "source.organizeImports": true
+    "[python]": {
+        "editor.codeActionsOnSave": {
+            "source.fixAll.ruff": false,
+            "source.organizeImports.ruff": true
+        }
     }
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -98,17 +98,16 @@ pygments_style = "sphinx"
 
 # This means you can link things like `str` and `asyncio` to the relevant
 # docs in the python documentation.
-intersphinx_mapping = dict(python=("https://docs.python.org/3/", None))
+intersphinx_mapping = {"python": ("https://docs.python.org/3/", None)}
 
 # A dictionary of graphviz graph attributes for inheritance diagrams.
-inheritance_graph_attrs = dict(rankdir="TB")
+inheritance_graph_attrs = {"rankdir": "TB"}
 
 # Common links that should be available on every page
 rst_epilog = """
 .. _Diamond Light Source: http://www.diamond.ac.uk
 .. _black: https://github.com/psf/black
-.. _flake8: https://flake8.pycqa.org/en/latest/
-.. _isort: https://github.com/PyCQA/isort
+.. _ruff: https://beta.ruff.rs/docs/
 .. _mypy: http://mypy-lang.org/
 .. _pre-commit: https://pre-commit.com/
 """
@@ -149,40 +148,40 @@ if not switcher_exists:
 # Point 3 makes checking switcher difficult, because the updated skeleton
 # will fix the switcher at the end of the docs workflow, but never gets a chance
 # to complete as the docs build warns and fails.
-html_theme_options = dict(
-    logo=dict(
-        text=project,
-    ),
-    use_edit_page_button=True,
-    github_url=f"https://github.com/{github_user}/{github_repo}",
-    icon_links=[
-        dict(
-            name="PyPI",
-            url=f"https://pypi.org/project/{project}",
-            icon="fas fa-cube",
-        )
+html_theme_options = {
+    "logo": {
+        "text": project,
+    },
+    "use_edit_page_button": True,
+    "github_url": f"https://github.com/{github_user}/{github_repo}",
+    "icon_links": [
+        {
+            "name": "PyPI",
+            "url": f"https://pypi.org/project/{project}",
+            "icon": "fas fa-cube",
+        }
     ],
-    switcher=dict(
-        json_url=switcher_json,
-        version_match=version,
-    ),
-    check_switcher=False,
-    navbar_end=["theme-switcher", "icon-links", "version-switcher"],
-    external_links=[
-        dict(
-            name="Release Notes",
-            url=f"https://github.com/{github_user}/{github_repo}/releases",
-        )
+    "switcher": {
+        "json_url": switcher_json,
+        "version_match": version,
+    },
+    "check_switcher": False,
+    "navbar_end": ["theme-switcher", "icon-links", "version-switcher"],
+    "external_links": [
+        {
+            "name": "Release Notes",
+            "url": f"https://github.com/{github_user}/{github_repo}/releases",
+        }
     ],
-)
+}
 
 # A dictionary of values to pass into the template engine’s context for all pages
-html_context = dict(
-    github_user=github_user,
-    github_repo=project,
-    github_version=version,
-    doc_path="docs",
-)
+html_context = {
+    "github_user": github_user,
+    "github_repo": project,
+    "github_version": version,
+    "doc_path": "docs",
+}
 
 # If true, "Created using Sphinx" is shown in the HTML footer. Default is True.
 html_show_sphinx = False

--- a/docs/developer/how-to/lint.rst
+++ b/docs/developer/how-to/lint.rst
@@ -1,7 +1,7 @@
 Run linting using pre-commit
 ============================
 
-Code linting is handled by black_, flake8_ and isort_ run under pre-commit_.
+Code linting is handled by black_ and ruff_ run under pre-commit_.
 
 Running pre-commit
 ------------------
@@ -26,14 +26,14 @@ repository::
 
     $ black .
 
-Likewise with isort::
+Likewise with ruff::
 
-    $ isort .
+    $ ruff --fix .
 
-If you get any flake8 issues you will have to fix those manually.
+Ruff may not be able to automatically fix all issues; in this case, you will have to fix those manually.
 
 VSCode support
 --------------
 
-The ``.vscode/settings.json`` will run black and isort formatters as well as
-flake8 checking on save. Issues will be highlighted in the editor window.
+The ``.vscode/settings.json`` will run black formatting as well as
+ruff checking on save. Issues will be highlighted in the editor window.

--- a/docs/developer/reference/standards.rst
+++ b/docs/developer/reference/standards.rst
@@ -10,8 +10,7 @@ Code Standards
 The code in this repository conforms to standards set by the following tools:
 
 - black_ for code formatting
-- flake8_ for style checks
-- isort_ for import ordering
+- ruff_ for style checks
 - mypy_ for static type checking
 
 .. seealso::

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,13 +26,12 @@ requires-python = ">=3.7"
 dev = [
     "black",
     "mypy",
-    "flake8-isort",
-    "Flake8-pyproject",
     "pipdeptree",
     "pre-commit",
     "pydata-sphinx-theme>=0.12",
     "pytest",
     "pytest-cov",
+    "ruff",
     "sphinx-autobuild",
     "sphinx-copybutton",
     "sphinx-design",
@@ -56,20 +55,6 @@ write_to = "src/python3_pip_skeleton/_version.py"
 
 [tool.mypy]
 ignore_missing_imports = true # Ignore missing stubs in imported modules
-
-[tool.isort]
-float_to_top = true
-profile = "black"
-
-[tool.flake8]
-extend-ignore = [
-    "E203", # See https://github.com/PyCQA/pycodestyle/issues/373
-    "F811", # support typing.overload decorator
-    "F722", # allow Annotated[typ, some_func("some string")]
-]
-max-line-length = 88 # Respect black's line length (default 88),
-exclude = [".tox", "venv"]
-
 
 [tool.pytest.ini_options]
 # Run pytest with all our checkers, and don't spam us with massive tracebacks on error
@@ -111,3 +96,15 @@ commands =
     pre-commit: pre-commit run --all-files {posargs}
     docs: sphinx-{posargs:build -EW --keep-going} -T docs build/html
 """
+
+
+[tool.ruff]
+src = ["src", "tests"]
+line-length = 88
+select = [
+    "C4",   # flake8-comprehensions - https://beta.ruff.rs/docs/rules/#flake8-comprehensions-c4
+    "E",    # pycodestyle errors - https://beta.ruff.rs/docs/rules/#error-e
+    "F",    # pyflakes rules - https://beta.ruff.rs/docs/rules/#pyflakes-f
+    "W",    # pycodestyle warnings - https://beta.ruff.rs/docs/rules/#warning-w
+    "I001", # isort
+]


### PR DESCRIPTION
Use `ruff` as a linter, as a replacement for `flake8` & `isort`.

`ruff` is much faster (Somewhere around 100x) than flake8+isort, and seems to be the direction which a lot of modern python projects are taking. It is [pretty much 1:1 compatible](https://beta.ruff.rs/docs/faq/#how-does-ruff-compare-to-flake8) with flake8 + isort, with very few exceptions.

To test this:
- Run `python -m pip install -e .[dev]` or an equivalent command to get `ruff` installed.
- Run `pre-commit` or `ruff .`, verify that `ruff` runs successfully
- Introduce a linting fail in a `.py` file in `src` or `tests`, verify that `ruff` picks this up
  * running `ruff .`
  * running `pre-commit`
- Launching `vscode` from this directory, verify that:
  * Ruff lints are reported (but not auto-fixed by default) in editor window. `ruff` can fix quite a lot of problems automatically but I found this somewhat surprising to run "on save", happy to hear other opinions about this?
  * Ruff automatically changes import *order* on save.
  * Note: may need to accept installing suggested extensions on first load of vscode on this branch.
- Verify that relevant docs have been updated to mention `ruff` instead of `flake8` or `isort`.