### PR TITLE
Fix docs build by providing default arg

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -173,6 +173,7 @@ html_theme_options = {
             "url": f"https://github.com/{github_user}/{github_repo}/releases",
         }
     ],
+    "navigation_with_keys": False,
 }
 
 # A dictionary of values to pass into the template engine’s context for all pages


### PR DESCRIPTION
To test:
* On main pull the latest dependencies, run `tox -e docs` and confirm it fails
* Do the same on this branch, confirm it passes