### PR TITLE
Bump upload/download artifact and configure dependabot to group them

### DIFF
--- a/.github/actions/install_requirements/action.yml
+++ b/.github/actions/install_requirements/action.yml
@@ -36,7 +36,7 @@ runs:
       shell: bash
 
     - name: Upload lockfiles
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: lockfiles
         path: lockfiles

--- a/.github/actions/install_requirements/action.yml
+++ b/.github/actions/install_requirements/action.yml
@@ -7,12 +7,12 @@ inputs:
   install_options:
     description: Parameters to pass to pip install
     required: true
+  artifact_name:
+    description: A user friendly name to give the produced artifacts
+    required: true
   python_version:
     description: Python version to install
     default: "3.x"
-  artifact_name:
-    description: A user friendly name to give the produced artifacts
-    default: "tests"
 
 runs:
   using: composite
@@ -39,7 +39,7 @@ runs:
       shell: bash
 
     - name: Upload lockfiles
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v4.0.0
       with:
         name: lockfiles-${{ inputs.python_version }}-${{ inputs.artifact_name }}-${{ github.sha }}
         path: lockfiles

--- a/.github/actions/install_requirements/action.yml
+++ b/.github/actions/install_requirements/action.yml
@@ -10,6 +10,9 @@ inputs:
   python_version:
     description: Python version to install
     default: "3.x"
+  artifact_name:
+    description: A user friendly name to give the produced artifacts
+    default: "tests"
 
 runs:
   using: composite
@@ -38,7 +41,7 @@ runs:
     - name: Upload lockfiles
       uses: actions/upload-artifact@v4
       with:
-        name: lockfiles-${{ inputs.python_version }}-${{ github.sha }}
+        name: lockfiles-${{ inputs.python_version }}-${{ inputs.artifact_name }}-${{ github.sha }}
         path: lockfiles
 
     # This eliminates the class of problems where the requirements being given no

--- a/.github/actions/install_requirements/action.yml
+++ b/.github/actions/install_requirements/action.yml
@@ -38,7 +38,7 @@ runs:
     - name: Upload lockfiles
       uses: actions/upload-artifact@v4
       with:
-        name: lockfiles
+        name: lockfiles-${{ inputs.python_version }}-${{ github.sha }}
         path: lockfiles
 
     # This eliminates the class of problems where the requirements being given no

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      github-artifacts:
+        patterns:
+          - actions/*-artifact
 
   - package-ecosystem: "pip"
     directory: "/"

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Upload sdist and wheel as artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: dist
+          name: dist-${{ github.sha }}
           path: dist
 
       - name: Check for packaging errors

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           requirements_file: requirements-dev-3.x.txt
           install_options: -e .[dev]
+          artifact_name: lint
 
       - name: Lint
         run: tox -e pre-commit,mypy
@@ -102,6 +103,7 @@ jobs:
           python_version: ${{env.CONTAINER_PYTHON}}
           requirements_file: requirements.txt
           install_options: dist/*.whl
+          artifact_name: dist
 
       - name: Test module --version works using the installed wheel
         # If more than one module in src/ replace with module name to test

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -88,7 +88,7 @@ jobs:
           pipx run build
 
       - name: Upload sdist and wheel as artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dist
           path: dist
@@ -127,7 +127,7 @@ jobs:
         run: echo IMAGE_REPOSITORY=ghcr.io/$(tr '[:upper:]' '[:lower:]' <<< "${{ github.repository }}") >> $GITHUB_ENV
 
       - name: Download wheel and lockfiles
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: artifacts/
 
@@ -146,9 +146,9 @@ jobs:
       - name: Build and export to Docker local cache
         uses: docker/build-push-action@v5
         with:
-        # Note build-args, context, file, and target must all match between this
-        # step and the later build-push-action, otherwise the second build-push-action
-        # will attempt to build the image again
+          # Note build-args, context, file, and target must all match between this
+          # step and the later build-push-action, otherwise the second build-push-action
+          # will attempt to build the image again
           build-args: |
             PIP_OPTIONS=-r lockfiles/requirements.txt dist/*.whl
           context: artifacts/
@@ -156,8 +156,8 @@ jobs:
           target: runtime
           load: true
           tags: ${{ env.TEST_TAG }}
-          # If you have a long docker build (2+ minutes), uncomment the 
-          # following to turn on caching. For short build times this 
+          # If you have a long docker build (2+ minutes), uncomment the
+          # following to turn on caching. For short build times this
           # makes it a little slower
           #cache-from: type=gha
           #cache-to: type=gha,mode=max
@@ -180,12 +180,12 @@ jobs:
       - name: Push cached image to container registry
         if: github.ref_type == 'tag' # || github.ref_name == 'main'
         uses: docker/build-push-action@v5
-        # This does not build the image again, it will find the image in the 
+        # This does not build the image again, it will find the image in the
         # Docker cache and publish it
         with:
-        # Note build-args, context, file, and target must all match between this
-        # step and the previous build-push-action, otherwise this step will 
-        # attempt to build the image again
+          # Note build-args, context, file, and target must all match between this
+          # step and the previous build-push-action, otherwise this step will
+          # attempt to build the image again
           build-args: |
             PIP_OPTIONS=-r lockfiles/requirements.txt dist/*.whl
           context: artifacts/
@@ -204,7 +204,7 @@ jobs:
       HAS_PYPI_TOKEN: ${{ secrets.PYPI_TOKEN != '' }}
 
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
 
       - name: Fixup blank lockfiles
         # Github release artifacts can't be blank

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -6,6 +6,7 @@ on:
 env:
   # The target python version, which must match the Dockerfile version
   CONTAINER_PYTHON: "3.11"
+  DIST_LOCKFILE_PATH: lockfiles-${{env.CONTAINER_PYTHON}}-dist-${{ github.sha }}
 
 jobs:
   lint:
@@ -152,7 +153,7 @@ jobs:
           # step and the later build-push-action, otherwise the second build-push-action
           # will attempt to build the image again
           build-args: |
-            PIP_OPTIONS=-r lockfiles/requirements.txt dist-${{ github.sha }}/*.whl
+            PIP_OPTIONS=-r ${{env.DIST_LOCKFILE_PATH}}/requirements.txt dist-${{ github.sha }}/*.whl
           context: artifacts/
           file: ./Dockerfile
           target: runtime
@@ -189,7 +190,7 @@ jobs:
           # step and the previous build-push-action, otherwise this step will
           # attempt to build the image again
           build-args: |
-            PIP_OPTIONS=-r lockfiles/requirements.txt dist-${{ github.sha }}/*.whl
+            PIP_OPTIONS=-r ${{env.DIST_LOCKFILE_PATH}}/requirements.txt dist-${{ github.sha }}/*.whl
           context: artifacts/
           file: ./Dockerfile
           target: runtime
@@ -210,7 +211,7 @@ jobs:
 
       - name: Fixup blank lockfiles
         # Github release artifacts can't be blank
-        run: for f in lockfiles*dist*/*; do [ -s $f ] || echo '# No requirements' >> $f; done
+        run: for f in ${{env.DIST_LOCKFILE_PATH}}/*; do [ -s $f ] || echo '# No requirements' >> $f; done
 
       - name: Github Release
         # We pin to the SHA, not the tag, for security reasons.
@@ -220,7 +221,7 @@ jobs:
           prerelease: ${{ contains(github.ref_name, 'a') || contains(github.ref_name, 'b') || contains(github.ref_name, 'rc') }}
           files: |
             dist-${{ github.sha }}/*
-            lockfiles*dist*/*
+            ${{env.DIST_LOCKFILE_PATH}}/*
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -6,6 +6,7 @@ on:
 env:
   # The target python version, which must match the Dockerfile version
   CONTAINER_PYTHON: "3.11"
+  DIST_WHEEL_PATH: dist-${{ github.sha }}
 
 jobs:
   lint:
@@ -83,11 +84,6 @@ jobs:
           # Need this to get version number from last tag
           fetch-depth: 0
 
-      - name: Set artifact locations in environment
-        run: |
-          echo "DIST_LOCKFILE_PATH=lockfiles-${{ env.CONTAINER_PYTHON }}-dist-${{ github.sha }}" >> $GITHUB_ENV
-          echo "DIST_WHEEL_PATH=dist-${{ github.sha }}" >> $GITHUB_ENV
-
       - name: Build sdist and wheel
         run: |
           export SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct) && \
@@ -132,6 +128,10 @@ jobs:
       # image names must be all lower case
       - name: Generate image repo name
         run: echo IMAGE_REPOSITORY=ghcr.io/$(tr '[:upper:]' '[:lower:]' <<< "${{ github.repository }}") >> $GITHUB_ENV
+
+      - name: Set lockfile location in environment
+        run: |
+          echo "DIST_LOCKFILE_PATH=lockfiles-${{ env.CONTAINER_PYTHON }}-dist-${{ github.sha }}" >> $GITHUB_ENV
 
       - name: Download wheel and lockfiles
         uses: actions/download-artifact@v4

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -152,7 +152,7 @@ jobs:
           # step and the later build-push-action, otherwise the second build-push-action
           # will attempt to build the image again
           build-args: |
-            PIP_OPTIONS=-r lockfiles/requirements.txt dist/*.whl
+            PIP_OPTIONS=-r lockfiles/requirements.txt dist-${{ github.sha }}/*.whl
           context: artifacts/
           file: ./Dockerfile
           target: runtime
@@ -189,7 +189,7 @@ jobs:
           # step and the previous build-push-action, otherwise this step will
           # attempt to build the image again
           build-args: |
-            PIP_OPTIONS=-r lockfiles/requirements.txt dist/*.whl
+            PIP_OPTIONS=-r lockfiles/requirements.txt dist-${{ github.sha }}/*.whl
           context: artifacts/
           file: ./Dockerfile
           target: runtime
@@ -210,7 +210,7 @@ jobs:
 
       - name: Fixup blank lockfiles
         # Github release artifacts can't be blank
-        run: for f in lockfiles/*; do [ -s $f ] || echo '# No requirements' >> $f; done
+        run: for f in lockfiles*dist*/*; do [ -s $f ] || echo '# No requirements' >> $f; done
 
       - name: Github Release
         # We pin to the SHA, not the tag, for security reasons.
@@ -219,8 +219,8 @@ jobs:
         with:
           prerelease: ${{ contains(github.ref_name, 'a') || contains(github.ref_name, 'b') || contains(github.ref_name, 'rc') }}
           files: |
-            dist/*
-            lockfiles/*
+            dist-${{ github.sha }}/*
+            lockfiles*dist*/*
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -60,6 +60,7 @@ jobs:
           python_version: ${{ matrix.python }}
           requirements_file: requirements-test-${{ matrix.os }}-${{ matrix.python }}.txt
           install_options: ${{ matrix.install }}
+          artifact_name: tests
 
       - name: List dependency tree
         run: pipdeptree
@@ -90,7 +91,7 @@ jobs:
           pipx run build
 
       - name: Upload sdist and wheel as artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.0.0
         with:
           name: ${{ env.DIST_WHEEL_PATH }}
           path: dist
@@ -134,7 +135,7 @@ jobs:
           echo "DIST_LOCKFILE_PATH=lockfiles-${{ env.CONTAINER_PYTHON }}-dist-${{ github.sha }}" >> $GITHUB_ENV
 
       - name: Download wheel and lockfiles
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v4.0.0
         with:
           path: artifacts/
 
@@ -211,7 +212,7 @@ jobs:
       HAS_PYPI_TOKEN: ${{ secrets.PYPI_TOKEN != '' }}
 
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v4.0.0
 
       - name: Fixup blank lockfiles
         # Github release artifacts can't be blank

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -6,7 +6,6 @@ on:
 env:
   # The target python version, which must match the Dockerfile version
   CONTAINER_PYTHON: "3.11"
-  DIST_LOCKFILE_PATH: lockfiles-${{env.CONTAINER_PYTHON}}-dist-${{ github.sha }}
 
 jobs:
   lint:
@@ -84,6 +83,11 @@ jobs:
           # Need this to get version number from last tag
           fetch-depth: 0
 
+      - name: Set artifact locations in environment
+        run: |
+          echo "DIST_LOCKFILE_PATH=lockfiles-${{ env.CONTAINER_PYTHON }}-dist-${{ github.sha }}" >> $GITHUB_ENV
+          echo "DIST_WHEEL_PATH=dist-${{ github.sha }}" >> $GITHUB_ENV
+
       - name: Build sdist and wheel
         run: |
           export SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct) && \
@@ -92,7 +96,7 @@ jobs:
       - name: Upload sdist and wheel as artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: dist-${{ github.sha }}
+          name: ${{ env.DIST_WHEEL_PATH }}
           path: dist
 
       - name: Check for packaging errors
@@ -153,7 +157,7 @@ jobs:
           # step and the later build-push-action, otherwise the second build-push-action
           # will attempt to build the image again
           build-args: |
-            PIP_OPTIONS=-r ${{env.DIST_LOCKFILE_PATH}}/requirements.txt dist-${{ github.sha }}/*.whl
+            PIP_OPTIONS=-r ${{ env.DIST_LOCKFILE_PATH }}/requirements.txt ${{ env.DIST_WHEEL_PATH }}/*.whl
           context: artifacts/
           file: ./Dockerfile
           target: runtime
@@ -190,7 +194,7 @@ jobs:
           # step and the previous build-push-action, otherwise this step will
           # attempt to build the image again
           build-args: |
-            PIP_OPTIONS=-r ${{env.DIST_LOCKFILE_PATH}}/requirements.txt dist-${{ github.sha }}/*.whl
+            PIP_OPTIONS=-r ${{ env.DIST_LOCKFILE_PATH }}/requirements.txt ${{ env.DIST_WHEEL_PATH }}/*.whl
           context: artifacts/
           file: ./Dockerfile
           target: runtime
@@ -211,7 +215,7 @@ jobs:
 
       - name: Fixup blank lockfiles
         # Github release artifacts can't be blank
-        run: for f in ${{env.DIST_LOCKFILE_PATH}}/*; do [ -s $f ] || echo '# No requirements' >> $f; done
+        run: for f in ${{ env.DIST_LOCKFILE_PATH }}/*; do [ -s $f ] || echo '# No requirements' >> $f; done
 
       - name: Github Release
         # We pin to the SHA, not the tag, for security reasons.
@@ -220,8 +224,8 @@ jobs:
         with:
           prerelease: ${{ contains(github.ref_name, 'a') || contains(github.ref_name, 'b') || contains(github.ref_name, 'rc') }}
           files: |
-            dist-${{ github.sha }}/*
-            ${{env.DIST_LOCKFILE_PATH}}/*
+            ${{ env.DIST_WHEEL_PATH }}/*
+            ${{ env.DIST_LOCKFILE_PATH }}/*
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           requirements_file: requirements-dev-3.x.txt
           install_options: -e .[dev]
+          artifact_name: docs
 
       - name: Build docs
         run: tox -e docs

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -19,6 +19,7 @@ jobs:
         with:
           requirements_file: requirements-dev-3.x.txt
           install_options: -e .[dev]
+          artifact_name: link_check
 
       - name: Check links
         run: tox -e docs build -- -b linkcheck


### PR DESCRIPTION
It's required to bump both dependencies at the same time.

To test:
* Confirm CI is passing and that we have artifacts for each job 