### PR TITLE
Fix release process after updating upload/download artifacts

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -216,12 +216,16 @@ jobs:
       - name: Download wheel and lockfiles
         uses: actions/download-artifact@v4.1.0
         with:
-          path: artifacts/
           pattern: "*dist*"
+
+      - name: Rename lockfiles and dist
+        run: |
+          mv lockfiles-${{ env.CONTAINER_PYTHON }}-dist-${{ github.sha }} lockfiles
+          mv ${{ env.DIST_WHEEL_PATH }} dist
 
       - name: Fixup blank lockfiles
         # Github release artifacts can't be blank
-        run: for f in ${{ env.DIST_LOCKFILE_PATH }}/*; do [ -s $f ] || echo '# No requirements' >> $f; done
+        run: for f in lockfiles/*; do [ -s $f ] || echo '# No requirements' >> $f; done
 
       - name: Github Release
         # We pin to the SHA, not the tag, for security reasons.
@@ -230,8 +234,8 @@ jobs:
         with:
           prerelease: ${{ contains(github.ref_name, 'a') || contains(github.ref_name, 'b') || contains(github.ref_name, 'rc') }}
           files: |
-            ${{ env.DIST_WHEEL_PATH }}/*
-            ${{ env.DIST_LOCKFILE_PATH }}/*
+            dist/*
+            lockfiles/*
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Bumping the version of upload/download artifacts (https://github.com/DiamondLightSource/python3-pip-skeleton/pull/161) has caused issues in the release process. This can be seen in https://github.com/DiamondLightSource/dodal/pull/276.

To test:
* Confirm the changes in dodal are now in here
* Confirm these changes fixed the release in dodal